### PR TITLE
Prevent crash when reading while client drop

### DIFF
--- a/src/vmod_zlib.c
+++ b/src/vmod_zlib.c
@@ -125,8 +125,7 @@ fill_pipeline(VRT_CTX, struct vsb** pvsb, struct http_conn *htc, ssize_t len)
 				htc->pipeline_e = NULL;
 			}
 			// XXX: VTCP_Assert(i); // but also: EAGAIN
-			VSLb(ctx->req->htc->vfc->wrk->vsl, SLT_FetchError,
-			    "%s", strerror(errno));
+			VSLb(ctx->vsl, SLT_FetchError, "%s", strerror(errno));
 			ctx->req->req_body_status = REQ_BODY_FAIL;
 			return (i);
 		}


### PR DESCRIPTION
ctx->req->htc->vfc->wrk is empty, but ctx->vsl is present.

(gdb) p ctx->req->htc->vfc->wrk
$9 = (struct worker *) 0x0
(gdb) p ctx->vsl
$11 = (struct vsl_log *) 0x2ad5d4951800